### PR TITLE
bigger buffer for larger files

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = function (filename, cb) {
   // We can't require.resolve('jsdoc')
   var cmd = __dirname + '/node_modules/jsdoc/jsdoc.js -X ' + filename;
 
-  exec(cmd, function (error, stdout) {
+  exec(cmd, { maxBuffer: 400 * 1024 }, function (error, stdout) {
     cb(error, JSON.parse(stdout));
   });
 };


### PR DESCRIPTION
This adds a bigger `maxBuffer` to circumvent an error that was occurring with larger input files.  Not sure if this is large enough for all uses, but gets past the error for me.

The error I was receiving was:

```
Error generating docs for file date-utils.js [Error: stdout maxBuffer exceeded.]
[Error: stdout maxBuffer exceeded.]
```
