### PR TITLE
Fix fatal parse error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,14 @@ module.exports = function (filename, cb) {
   var cmd = path.join(__dirname, 'node_modules', '.bin', win32 ? 'jsdoc.cmd' : 'jsdoc');
 
   execFile(cmd, ['-X', filename], { maxBuffer: 5120 * 1024 }, function (error, stdout) {
-    cb(error, JSON.parse(stdout));
+    var parsed;
+  	try {
+  		parsed = JSON.parse(stdout);
+  	} catch (ex){
+  		console.error('Error on', filename, ex);
+  		parsed = null;
+  		error = ex;
+  	}
+  	cb(error, parsed);
   });
 };


### PR DESCRIPTION
Fix an issue that was occurring when jsdoc echoed output that was not valid JSON. This would cause a fatal error and halt the program, even though the standard approach would be to return the error with the callback. 

Invalid output might occur if a file is not documented or if there is an issue opening the file.