### PR TITLE
feat(pkg): use resolve-jsdoc-bin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,43 +1,8 @@
 var execFile = require('child_process').execFile,
     fs = require('fs'),
     os = require('os'),
-    path = require('path');
-
-/**
- * Locates the JSDoc executable command. Since a module is not provided,
- * `require.resolve('jsdoc')` does not work and must be done manually.
- *
- * @param {String}  dir - The starting directory to search.
- * @return {String} The executable path, or null if not found.
- */
-function locateJSDocCommand(dir) {
-  var executable = os.platform() === 'win32' ? 'jsdoc.cmd' : 'jsdoc',
-      cmd;
-
-  dir = path.resolve(dir);
-
-  while (dir) {
-    try {
-      cmd = path.join(dir, 'node_modules', '.bin', executable);
-      // End the search if the command is found.
-      // If not found, an exception is thrown.
-      fs.statSync(cmd);
-      break;
-
-    } catch (ex) {
-      cmd = null;
-
-      // Otherwise, iterate to the parent directory, if possible.
-      if (path.dirname(dir) === dir) {
-        break;
-      }
-
-      dir = path.resolve(path.dirname(dir));
-    }
-  }
-
-  return cmd;
-}
+    path = require('path'),
+    resolveJsdocBin = require('resolve-jsdoc-bin');
 
 /**
  * Parses the given file using JSDoc's parser.
@@ -48,7 +13,7 @@ function locateJSDocCommand(dir) {
  * @param  {Function} cb       ({Object}) -> null - Executed with the AST
  */
 function jsdocParser(filename, cb) {
-  var cmd = locateJSDocCommand(__dirname);
+  var cmd = resolveJsdocBin.resolve(__dirname);
 
   if (!cmd) {
     cb(new Error('Could not find jsdoc command.'), null);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "homepage": "https://github.com/mrjoelkemp/jsdoc3-parser",
   "dependencies": {
-    "jsdoc": "^3.3.0-alpha11"
+    "jsdoc": "^3.3.0-alpha11",
+    "resolve-jsdoc-bin": "^1.0.0"
   },
   "devDependencies": {
     "jscs": "~1.10.0",


### PR DESCRIPTION
# problem statement

- i needed to resolve the jsdoc bin as well

# solution

- i abstracted it into a separate pkg

# discussion

- there were some missing edge cases (i.e. if an invalid root dir was provided, if no dir was found at all) that are now implemented and tested (cross platform!)